### PR TITLE
fix: Remote hangups

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,10 @@ main() {
   # Using git directly because the $GITHUB_EVENT_PATH file only shows commits in
   # most recent push.
   /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin master
-  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude=master origin ${BRANCH}
+  if [ "$BRANCH" != "master" ]; then
+    /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude=master origin ${BRANCH}
+  fi
+
 
   # Get the list before the "|| true" to fail the script when the git cmd fails.
   FIXUP_LIST=`/usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH}`


### PR DESCRIPTION
Was able to reproduce. Don't use shallow-exclude with the current
branch:

```
$ /usr/bin/git fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude=master origin master
fatal: The remote end hung up unexpectedly
```