### PR TITLE
feat: Block --squash commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Block Fixup Commit Merge Action
 
-Love using `git commit --fixup` to make cleanups to your Git history, especially
-during Code Reviews, but forget to `git rebase -i --autosquash master` before
+Love using `git commit --fixup` or `git commit --squash` to make cleanups to
+your Git history, but forget to `git rebase -i --autosquash master` before
 merging?
 
 Have I got a Github Action for you!
 
-This Action is as an assistant to be sure your squash fixup commits before
+This Action is as an assistant to be sure you squash fixup commits before
 merging to your main branch.
 
 ## Background

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 set -o pipefail
+
 main() {
   echo "Current ref: ${GITHUB_REF}"
   BRANCH=${GITHUB_REF:11}
@@ -15,13 +16,21 @@ main() {
   # most recent push.
   /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin master
   /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude=master origin ${BRANCH}
-
   # Get the list before the "|| true" to fail the script when the git cmd fails.
-  FIXUP_LIST=`/usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH}`
-  FIXUP_COUNT=`echo $FIXUP_LIST | grep fixup! | wc -l || true`
+  COMMIT_LIST=`/usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH}`
+
+  FIXUP_COUNT=`echo $COMMIT_LIST | grep fixup! | wc -l || true`
   echo "Fixup! commits: ${FIXUP_COUNT}"
   if [ "$FIXUP_COUNT" -gt "0" ]; then
     /usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH} | grep fixup!
+    echo "failing..."
+    exit 1
+  fi
+
+  SQUASH_COUNT=`echo $COMMIT_LIST | grep squash! | wc -l || true`
+  echo "Squash! commits: ${SQUASH_COUNT}"
+  if [ "$SQUASH_COUNT" -gt "0" ]; then
+    /usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH} | grep squash!
     echo "failing..."
     exit 1
   fi


### PR DESCRIPTION
Adds support for blocking commits made with:
```
--squash=<commit>
    Construct a commit message for use with rebase --autosquash. The commit message subject line is taken from
    the specified commit with a prefix of "squash! ". Can be used with additional commit message options
    (-m/-c/-C/-F). See git-rebase(1) for details.
```
fixes #14