### PR TITLE
Rewrite branch logic to allow base branches other than master

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,6 +1,6 @@
 name: Git Checks
 
-on: [push]
+on: [pull_request]
 
 jobs:
   block-fixup:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ following:
 ```yaml
 name: Git Checks
 
-on: [push]
+on: [pull_request]
 
 jobs:
   block-fixup:
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.0.0
     - name: Block Fixup Commit Merge
-      uses: 13rac1/block-fixup-merge-action@v1.1.2
+      uses: 13rac1/block-fixup-merge-action@v2.0.0
 ```
 
 Optionally, setup Branch Protection to block merging of PRs against the `master`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,42 +1,37 @@
 #!/bin/bash
-set -e
-set -o pipefail
+set -eo pipefail
 
 main() {
-  echo "Current ref: ${GITHUB_REF}"
+  PR_REF="${GITHUB_REF%/merge}/head"
+  BASE_REF="${GITHUB_BASE_REF}"
 
-  if [[ "$GITHUB_REF" != "refs/heads/"* ]]; then
-    echo "Only check branches, not tags or other refs."
-    exit 0
-  fi
+  echo "Current ref: ${PR_REF}"
+  echo "Base ref: ${BASE_REF}"
 
-  BRANCH=${GITHUB_REF:11}
-  echo "Current branch: ${BRANCH}"
-
-  if [ "$BRANCH" == "master" ]; then
-    echo "No check of master branch needed."
-    exit 0
+  if [[ "$PR_REF" != "refs/pull/"* ]]; then
+    echo "This check works only with pull_request events"
+    exit 1
   fi
 
   # Using git directly because the $GITHUB_EVENT_PATH file only shows commits in
   # most recent push.
-  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin master
-  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude=master origin ${BRANCH}
+  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "${BASE_REF}:__ci_base"
+  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude="${BASE_REF}" origin "${PR_REF}:__ci_pr"
   # Get the list before the "|| true" to fail the script when the git cmd fails.
-  COMMIT_LIST=`/usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH}`
+  COMMIT_LIST=`/usr/bin/git log --pretty=format:%s __ci_base..__ci_pr`
 
   FIXUP_COUNT=`echo $COMMIT_LIST | grep fixup! | wc -l || true`
-  echo "Fixup! commits: ${FIXUP_COUNT}"
-  if [ "$FIXUP_COUNT" -gt "0" ]; then
-    /usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH} | grep fixup!
+  echo "Fixup! commits: $FIXUP_COUNT"
+  if [[ "$FIXUP_COUNT" -gt "0" ]]; then
+    /usr/bin/git log --pretty=format:%s __ci_base..__ci_pr | grep fixup!
     echo "failing..."
     exit 1
   fi
 
   SQUASH_COUNT=`echo $COMMIT_LIST | grep squash! | wc -l || true`
-  echo "Squash! commits: ${SQUASH_COUNT}"
-  if [ "$SQUASH_COUNT" -gt "0" ]; then
-    /usr/bin/git log --pretty=format:%s origin/master..origin/${BRANCH} | grep squash!
+  echo "Squash! commits: $SQUASH_COUNT"
+  if [[ "$SQUASH_COUNT" -gt "0" ]]; then
+    /usr/bin/git log --pretty=format:%s __ci_base..__ci_pr | grep squash!
     echo "failing..."
     exit 1
   fi


### PR DESCRIPTION
As a consequence of how it now works, it can no longer be run on non-`pull_request` events.

Fixes #2.