### PR TITLE
fix: cover Git 2.32.0, check for `amend!` commits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ main() {
   # Get the list before the "|| true" to fail the script when the git cmd fails.
   COMMIT_LIST=`/usr/bin/git log --pretty=format:%s __ci_base..__ci_pr`
 
-  FIXUP_COUNT=`echo $COMMIT_LIST | grep fixup! | wc -l || true`
+  FIXUP_COUNT=`echo $COMMIT_LIST | grep -E 'fixup!|amend!' | wc -l || true`
   echo "Fixup! commits: $FIXUP_COUNT"
   if [[ "$FIXUP_COUNT" -gt "0" ]]; then
     /usr/bin/git log --pretty=format:%s __ci_base..__ci_pr | grep fixup!


### PR DESCRIPTION
This adds coverage for the new `amend!` commit prefixes [added with the `--fixup={reword,amend}...` variants][git-2-32-announcement].

[git-2-32-announcement]: https://github.com/git/git/blob/8b7c11b8668b4e774f81a9f0b4c30144b818f1d1/Documentation/RelNotes/2.32.0.txt#L44-L48

---

I'm unclear on whether or not this would be considered a breaking change?

Closes #25.