### PR TITLE
Satisfy shellcheck

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,9 @@ main() {
   /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "${BASE_REF}:__ci_base"
   /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --shallow-exclude="${BASE_REF}" origin "${PR_REF}:__ci_pr"
   # Get the list before the "|| true" to fail the script when the git cmd fails.
-  COMMIT_LIST=`/usr/bin/git log --pretty=format:%s __ci_base..__ci_pr`
+  COMMIT_LIST=$(/usr/bin/git log --pretty=format:%s __ci_base..__ci_pr)
 
-  FIXUP_COUNT=`echo $COMMIT_LIST | grep fixup! | wc -l || true`
+  FIXUP_COUNT=$(echo "$COMMIT_LIST" | grep -c 'fixup!' || true)
   echo "Fixup! commits: $FIXUP_COUNT"
   if [[ "$FIXUP_COUNT" -gt "0" ]]; then
     /usr/bin/git log --pretty=format:%s __ci_base..__ci_pr | grep fixup!
@@ -28,7 +28,7 @@ main() {
     exit 1
   fi
 
-  SQUASH_COUNT=`echo $COMMIT_LIST | grep squash! | wc -l || true`
+  SQUASH_COUNT=$(echo "$COMMIT_LIST" | grep -c 'squash!' || true)
   echo "Squash! commits: $SQUASH_COUNT"
   if [[ "$SQUASH_COUNT" -gt "0" ]]; then
     /usr/bin/git log --pretty=format:%s __ci_base..__ci_pr | grep squash!


### PR DESCRIPTION
$> shellcheck --format gcc entrypoint.sh
entrypoint.sh:21:15: note: Use $(...) notation instead of legacy backticks `...`. [SC2006]
entrypoint.sh:23:15: note: Use $(...) notation instead of legacy backticks `...`. [SC2006]
entrypoint.sh:23:21: note: Double quote to prevent globbing and word splitting. [SC2086]
entrypoint.sh:23:36: note: Consider using grep -c instead of grep|wc -l. [SC2126]
entrypoint.sh:31:16: note: Use $(...) notation instead of legacy backticks `...`. [SC2006]
entrypoint.sh:31:22: note: Double quote to prevent globbing and word splitting. [SC2086]
entrypoint.sh:31:37: note: Consider using grep -c instead of grep|wc -l. [SC2126]