### PR TITLE
feat: using composite action instead of Docker based

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -4,9 +4,9 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-slim
 
     steps:
-    - uses: actions/checkout@v2.0.0 # Always pin
+    - uses: actions/checkout@v6
     - name: Block Fixup/Squash Merge
-      uses: 13rac1/block-fixup-merge-action@master
+      uses: acolombier/block-fixup-merge-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine:3.10
-
-RUN apk add --no-cache \
-  bash \
-  git
-COPY entrypoint.sh /entrypoint.sh
-
-CMD ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,10 @@ name: 'Block fixup commit merge'
 description: 'Block merge of Pull Requests containing fixup commits, so you do not forget to squash/autosquash.'
 author: 'Brad Erickson'
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'composite'
+  steps:
+  - shell: bash
+    run: ${{ github.action_path }}/entrypoint.sh
 branding:
   icon: 'scissors'
   color: 'orange'


### PR DESCRIPTION
The Docker runtime is redundant and limit the ability to run the action on cheaper and faster `ubuntu-slim` runners